### PR TITLE
commit modified version #11

### DIFF
--- a/src/common/DoRequest.ts
+++ b/src/common/DoRequest.ts
@@ -15,6 +15,8 @@ import path = require('path');
 /* eslint-enable */
 
 const Message = Config.ReadConfig('./config/message.json');
+const dns = require('dns');
+dns.setDefaultResultOrder('ipv4first');
 
 /**
  * 汎用性特化型リクエスト関数


### PR DESCRIPTION
# pullrequestタイトル
node18からipv6が優先することに伴いlocalhostの通信に失敗する。

# 概要
## 環境（UT実行バージョン）
- postgres: 15.5
```
$ psql --version
psql (PostgreSQL) 15.5
```
- node: v18.16.0
```
$ fnm use 18
Using Node v18.16.0
```

## 対処内容
- nodejsの通信をipv6優先→ipv4優先に修正した。
- src/common/DoRequest.ts内で以下を追記し、ipv4を優先して利用する設定を入れた。
```
const dns = require('dns');
dns.setDefaultResultOrder('ipv4first');
```

# コマンド実行結果
## npm install実行結果
```
$ npm install
npm WARN deprecated @types/moment@2.13.0: This is a stub types definition for Moment (https://github.com/moment/moment). Moment provides its own type definitions, so you don't need @types/moment installed!
npm WARN deprecated @types/helmet@4.0.0: This is a stub types definition. helmet provides its own type definitions, so you do not need this installed.
npm WARN deprecated @babel/plugin-proposal-export-namespace-from@7.18.9: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.
npm WARN deprecated har-validator@5.1.3: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

added 1057 packages, and audited 1058 packages in 7m

153 packages are looking for funding
  run `npm fund` for details

10 vulnerabilities (6 moderate, 1 high, 3 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible, run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
npm notice
npm notice New major version of npm available! 9.5.1 -> 10.5.0
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.5.0>
npm notice Run `npm install -g npm@10.5.0` to update!

```

## ビルド実行結果
```
$ npm run build

> access-control-manage-service@1.0.0 build
> npm-run-all -s lint build:ts


> access-control-manage-service@1.0.0 lint
> eslint ./src/index.ts src/**/*.ts


> access-control-manage-service@1.0.0 build:ts
> node ./node_modules/typescript/bin/tsc

```

## UT実行結果
```
$ npm run test:unit

> access-control-manage-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

PASS src/tests/CreateSettingAPIKey.spec.ts (112.34 s)
PASS src/tests/CreateShareContinuousAPIKey.spec.ts (35.854 s)
  ● Console

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

    console.log
      get

      at src/tests/NonDataStubs.ts:187:21

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

PASS src/tests/CreateActorAPIKey.spec.ts (5.383 s)
PASS src/tests/CreateShareTempAPIKey.spec.ts (13.806 s)
PASS src/tests/CreateAPIKey.validator.spec.ts (13.174 s)
PASS src/tests/CreateStoreAPIKey.spec.ts (8.793 s)
  ● Console

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

PASS src/tests/CreateAppWfUserAPIKey.spec.ts (5.642 s)
PASS src/tests/CreateBookAPIKey.spec.ts (5.001 s)
PASS src/tests/CreateCatalogAPIKey.spec.ts
  ● Console

    console.log
      Missing this namespace for test: catalog/ext/test-org/setting/actor/app/actor_1000021

      at src/tests/StubServer.ts:607:25

PASS src/tests/CreateJoinAPIKey.spec.ts
(node:1360) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
PASS src/tests/CreateBlockAPIKey.spec.ts (5.974 s)
PASS src/tests/CreateOperatorAPIKey.spec.ts
  ● Console

    console.log
      Missing this namespace for test: catalog/model/auth/not_exists

      at src/tests/StubServer.ts:607:25

    console.log
      Missing this namespace for test: catalog/model/setting/actor/pxr-root

      at src/tests/StubServer.ts:607:25

-------------------------------------------|---------|----------|---------|---------|-------------------------
File                                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------|---------|----------|---------|---------|-------------------------
All files                                  |   98.83 |    88.97 |      96 |   98.84 |
 domains                                   |   97.48 |      100 |   92.18 |   97.38 |
  ActorCatalogDomain.ts                    |     100 |      100 |     100 |     100 |
  BlockCatalogDomain.ts                    |     100 |      100 |     100 |     100 |
  MyBookListElement.ts                     |     100 |      100 |     100 |     100 |
  NumberCToken.ts                          |     100 |      100 |     100 |     100 |
  SharingCatalog.ts                        |   96.15 |      100 |   88.88 |   96.15 | 14
  SharingDataDefinition.ts                 |     100 |      100 |     100 |     100 |
  SharingRestrintionCatalog.ts             |   91.66 |      100 |   78.94 |   91.66 | 26,32,45,70
  TemporarySharingDataDefinition.ts        |     100 |      100 |     100 |     100 |
 repositories                              |     100 |      100 |     100 |     100 |
  EntityOperation.ts                       |     100 |      100 |     100 |     100 |
 repositories/postgres                     |     100 |      100 |     100 |     100 |
  CallerRole.ts                            |     100 |      100 |     100 |     100 |
  TokenAccessHistory.ts                    |     100 |      100 |     100 |     100 |
  TokenGenerationHistory.ts                |     100 |      100 |     100 |     100 |
 resources                                 |   99.77 |    91.07 |     100 |   99.75 |
  CreateActorAPIKeyController.ts           |     100 |      100 |     100 |     100 |
  CreateAppWfUserAPIKeyController.ts       |     100 |      100 |     100 |     100 |
  CreateBlockAPIKeyController.ts           |     100 |      100 |     100 |     100 |
  CreateBookAPIKeyController.ts            |     100 |      100 |     100 |     100 |
  CreateCatalogAPIKeyController.ts         |     100 |      100 |     100 |     100 |
  CreateJoinAPIKeyController.ts            |     100 |      100 |     100 |     100 |
  CreateOperatorAPIKeyController.ts        |     100 |      100 |     100 |     100 |
  CreateSettingAPIKeyController.ts         |     100 |      100 |     100 |     100 |
  CreateShareContinuousAPIKeyController.ts |     100 |    85.71 |     100 |     100 | 66-70
  CreateShareTempAPIKeyController.ts       |     100 |    83.33 |     100 |     100 | 57
  CreateStoreAPIKeyController.ts           |   97.82 |       60 |     100 |   97.67 | 53
 resources/dto                             |   98.31 |      100 |   94.44 |   98.23 |
  CreateAPIKeyReqDto.ts                    |    97.5 |      100 |    90.9 |   97.22 | 39
  CreateShareContinuousAPIKeyReqDto.ts     |   97.77 |      100 |   93.33 |   97.72 | 37
  CreateShareTempAPIKeyReqDto.ts           |     100 |      100 |     100 |     100 |
 resources/validator                       |    97.8 |    94.11 |     100 |   97.59 |
  BaseValidator.ts                         |   93.33 |    83.33 |     100 |   92.85 | 73,79
  CreateBlockAPIKeyValidator.ts            |     100 |      100 |     100 |     100 |
  CreateShareContinuousAPIKeyValidator.ts  |     100 |      100 |     100 |     100 |
  CreateShareTempAPIKeyValidator.ts        |     100 |      100 |     100 |     100 |
  CreateStoreAPIKeyValidator.ts            |     100 |      100 |     100 |     100 |
 services                                  |   98.63 |    88.05 |   98.43 |   98.77 |
  AccessControlService.ts                  |     100 |      100 |     100 |     100 |
  BookManageService.ts                     |   97.95 |    71.42 |     100 |   97.95 | 82
  CTokenLedgerService.ts                   |     100 |      100 |     100 |     100 |
  CatalogService.ts                        |     100 |    84.61 |     100 |     100 | 35,157
  CreateAPIKeyService.ts                   |   96.88 |    75.78 |   95.23 |    97.3 | 170-171,278,464,473,500
  IdService_Stub.ts                        |     100 |      100 |     100 |     100 |
  SharingDataService.ts                    |     100 |    99.31 |     100 |     100 | 269
 services/dto                              |     100 |      100 |     100 |     100 |
  AccessControllerResult.ts                |     100 |      100 |     100 |     100 |
-------------------------------------------|---------|----------|---------|---------|-------------------------

Test Suites: 12 passed, 12 total
Tests:       210 passed, 210 total
Snapshots:   0 total
Time:        232.847 s
Ran all test suites.

Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  TCPWRAP

      at Connection.connect (node_modules/pg/lib/connection.js:44:17)
      at Client._connect (node_modules/pg/lib/client.js:113:11)
      at Client.connect (node_modules/pg/lib/client.js:162:12)
      at BoundPool.newClient (node_modules/pg-pool/index.js:237:12)
      at BoundPool.connect (node_modules/pg-pool/index.js:212:10)
      at src/driver/postgres/PostgresDriver.ts:1507:18
      at PostgresDriver.createPool (src/driver/postgres/PostgresDriver.ts:1506:16)
      at PostgresDriver.connect (src/driver/postgres/PostgresDriver.ts:346:38)
      at DataSource.initialize (src/data-source/DataSource.ts:249:27)
      at DataSource.connect (src/data-source/DataSource.ts:293:21)
      at createConnection (src/globals.ts:100:51)
      at src/common/Connection.ts:31:44
      at src/common/Connection.ts:8:71
      at Object.<anonymous>.__awaiter (src/common/Connection.ts:4:12)
      at connectDatabase (src/common/Connection.ts:37:12)
      at src/index.ts:10:30
      at src/index.ts:8:71
      at Object.<anonymous>.__awaiter (src/index.ts:4:12)
      at src/index.ts:8:13
      at Object.<anonymous> (src/index.ts:15:3)
      at Object.<anonymous> (src/tests/CreateOperatorAPIKey.spec.ts:7:1)

```

## 補足
- UT実行時にTCPWRAPのコネクションのワーニングが発生する。
  - jest関連でUTのみ発生する、かつUT自体にはパスしているため本問題に対する対応は実施していない。