### PR TITLE
継続的共有／一時的共有のレスポンスが配列にならない場合がある問題の修正 issue/#15

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -21,6 +21,8 @@ bookManageService:
     getSharingDataDefinition: http://localhost:3005/book-manage/setting/share/
     collationTemporaryShareCode: http://localhost:3005/book-manage/share/temp/collation
     getBookInd: http://localhost:3005/book-manage/
+    postStorePermission: http://localhost:3005/book-manage/settings/store/permission
+    postSharePermission: http://localhost:3005/book-manage/setting/share/permission
 
 accessControlService:
     local:

--- a/src/resources/CreateShareTempAPIKeyController.ts
+++ b/src/resources/CreateShareTempAPIKeyController.ts
@@ -19,6 +19,9 @@ import CTokenLedgerService from '../services/CTokenLedgerService';
 import CatalogService from '../services/CatalogService';
 import SharingDataService from '../services/SharingDataService';
 import { applicationLogger } from '../common/logging';
+import moment = require('moment');
+import config = require('config');
+import { DateTimeFormatString } from '../common/Transform';
 /* eslint-enable */
 
 @JsonController('/access-control-manage')
@@ -85,6 +88,12 @@ export default class {
             // アクターコード配列をブロックコード配列にする
             const blockCodes = await CatalogService.getBlockCodesWithActorCodes(actorCodes, operator);
 
+            // APIキーに設定する有効期限の取得
+            const expirationDate = moment(new Date())
+                .add(parseInt(config.get('standardTime')), 'hours')
+                .add(parseInt(config.get('defaultExpire.addMinutes')), 'minutes')
+                .format(DateTimeFormatString);
+
             // ブロックコード分、APIキーを発行する
             for (const blockCode of blockCodes) {
                 // ドメインを取得する
@@ -98,7 +107,8 @@ export default class {
                     domains.toCatalog,
                     domains.fromCatalog,
                     item,
-                    operator
+                    operator,
+                    expirationDate
                 );
                 // 結果が空であれば、次の処理へ
                 if (!tokenList.length) {

--- a/src/services/AccessControlService.ts
+++ b/src/services/AccessControlService.ts
@@ -31,7 +31,8 @@ export default class AccessControlService {
         toDomain: BlockCatalogDomain,
         fromDomain: BlockCatalogDomain,
         item: CreateAPIKeyReqDto,
-        operator: OperatorDomain
+        operator: OperatorDomain,
+        expirationDate :string = null
     ) {
         // 個人であればstatusを確認する
         if (operator.type === OperatorDomain.TYPE_PERSONAL_NUMBER) {
@@ -39,7 +40,7 @@ export default class AccessControlService {
         }
 
         // リクエストデータを生成する
-        const at = moment(new Date())
+        const at = expirationDate || moment(new Date())
             .add(parseInt(config.get('standardTime')), 'hours')
             .add(parseInt(config.get('defaultExpire.addMinutes')), 'minutes')
             .format(DateTimeFormatString);


### PR DESCRIPTION
## 修正内容
* 共有で同時に発行されるAPIキーの有効期限が同一になるように修正
* config/default.ymlにbook-manageへのpostStorePermission/postSharePermissionを追加。
  * localhost:3005のポート番号設定は、book-manage側のconfig/default.ymlと、manifestに依存。

fixes #15

## UT環境
~~~
$ node --version
v18.16.0

$ PGPASSWORD="postgres" psql -U postgres -h localhost -p 5432 -c "SELECT version();"
                          version
------------------------------------------------------------
 PostgreSQL 15.7, compiled by Visual C++ build 1939, 64-bit
(1 行)
~~~

## UT実行結果
~~~
$ npm run test:unit

> access-control-manage-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

PASS src/tests/CreateStoreAPIKey.spec.ts (12.655 s)
  ● Console

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

PASS src/tests/CreateShareTempAPIKey.spec.ts (6.652 s)
PASS src/tests/CreateShareContinuousAPIKey.spec.ts (7.106 s)
  ● Console

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

PASS src/tests/CreateSettingAPIKey.spec.ts
PASS src/tests/CreateOperatorAPIKey.spec.ts
  ● Console

    console.log
      Missing this namespace for test: catalog/model/auth/not_exists

      at src/tests/StubServer.ts:616:25

    console.log
      Missing this namespace for test: catalog/model/setting/actor/pxr-root

      at src/tests/StubServer.ts:616:25

PASS src/tests/CreateJoinAPIKey.spec.ts
PASS src/tests/CreateCatalogAPIKey.spec.ts
  ● Console

    console.log
      Missing this namespace for test: catalog/ext/test-org/setting/actor/app/actor_1000021

      at src/tests/StubServer.ts:616:25

PASS src/tests/CreateBookAPIKey.spec.ts
PASS src/tests/CreateBlockAPIKey.spec.ts
PASS src/tests/CreateAppWfUserAPIKey.spec.ts
(node:20992) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
PASS src/tests/CreateAPIKey.validator.spec.ts
PASS src/tests/CreateActorAPIKey.spec.ts
-------------------------------------------|---------|----------|---------|---------|-------------------------
File                                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------------------------------|---------|----------|---------|---------|-------------------------
All files                                  |   94.28 |    84.19 |   85.41 |   94.21 |                
 domains                                   |   73.86 |      100 |   65.62 |   72.77 |                
  ActorCatalogDomain.ts                    |     100 |      100 |     100 |     100 |                
  BlockCatalogDomain.ts                    |     100 |      100 |     100 |     100 |                
  MyBookListElement.ts                     |     100 |      100 |     100 |     100 |                
  NumberCToken.ts                          |     100 |      100 |     100 |     100 |                
  SharingCatalog.ts                        |       0 |      100 |       0 |       0 | 6-72           
  SharingDataDefinition.ts                 |       0 |      100 |       0 |       0 | 6-51           
  SharingRestrintionCatalog.ts             |   85.41 |      100 |   63.15 |   85.41 | 26,32,45,57,70,82,101
  TemporarySharingDataDefinition.ts        |     100 |      100 |     100 |     100 |                
 repositories                              |     100 |      100 |     100 |     100 |                
  EntityOperation.ts                       |     100 |      100 |     100 |     100 |                
 repositories/postgres                     |     100 |      100 |     100 |     100 |                
  CallerRole.ts                            |     100 |      100 |     100 |     100 |                
  TokenAccessHistory.ts                    |     100 |      100 |     100 |     100 |                
  TokenGenerationHistory.ts                |     100 |      100 |     100 |     100 |                
 resources                                 |   99.77 |    90.16 |     100 |   99.75 |                
  CreateActorAPIKeyController.ts           |     100 |      100 |     100 |     100 |                
  CreateAppWfUserAPIKeyController.ts       |     100 |      100 |     100 |     100 |                
  CreateBlockAPIKeyController.ts           |     100 |      100 |     100 |     100 |                
  CreateBookAPIKeyController.ts            |     100 |      100 |     100 |     100 |                
  CreateCatalogAPIKeyController.ts         |     100 |      100 |     100 |     100 |                
  CreateJoinAPIKeyController.ts            |     100 |      100 |     100 |     100 |                
  CreateOperatorAPIKeyController.ts        |     100 |      100 |     100 |     100 |                
  CreateSettingAPIKeyController.ts         |     100 |      100 |     100 |     100 |                
  CreateShareContinuousAPIKeyController.ts |     100 |    84.21 |     100 |     100 | 68-72,90       
  CreateShareTempAPIKeyController.ts       |     100 |    83.33 |     100 |     100 | 60             
  CreateStoreAPIKeyController.ts           |   97.82 |       60 |     100 |   97.67 | 53             
 resources/dto                             |   98.37 |      100 |   94.73 |   98.29 |                
  CreateAPIKeyReqDto.ts                    |    97.5 |      100 |    90.9 |   97.22 | 39             
  CreateShareContinuousAPIKeyReqDto.ts     |   97.95 |      100 |   94.11 |   97.91 | 37             
  CreateShareTempAPIKeyReqDto.ts           |     100 |      100 |     100 |     100 |                
 resources/validator                       |    97.8 |    94.11 |     100 |   97.59 |                
  BaseValidator.ts                         |   93.33 |    83.33 |     100 |   92.85 | 73,79          
  CreateBlockAPIKeyValidator.ts            |     100 |      100 |     100 |     100 |                
  CreateShareContinuousAPIKeyValidator.ts  |     100 |      100 |     100 |     100 |                
  CreateShareTempAPIKeyValidator.ts        |     100 |      100 |     100 |     100 |                
  CreateStoreAPIKeyValidator.ts            |     100 |      100 |     100 |     100 |                
 services                                  |   94.75 |    81.42 |   92.72 |   95.25 |                
  AccessControlService.ts                  |     100 |      100 |     100 |     100 |                
  BookManageService.ts                     |     100 |      100 |     100 |     100 |                
  CTokenLedgerService.ts                   |   92.85 |    91.66 |     100 |   92.85 | 29,35          
  CatalogService.ts                        |   91.54 |    83.33 |    90.9 |   91.42 | 50-51,128,141-143
  CreateAPIKeyService.ts                   |   97.48 |    73.63 |   94.73 |   97.95 | 199,385,394,421
  IdService_Stub.ts                        |     100 |      100 |     100 |     100 |                
  SharingDataService.ts                    |   88.07 |    85.29 |   83.33 |   89.21 | 173,191,198,203,210-218
 services/dto                              |     100 |      100 |     100 |     100 |                
  AccessControllerResult.ts                |     100 |      100 |     100 |     100 |                
-------------------------------------------|---------|----------|---------|---------|-------------------------

Test Suites: 12 passed, 12 total
Tests:       200 passed, 200 total
Snapshots:   0 total
Time:        57.365 s
Ran all test suites.
~~~