### PR TITLE
bugfix/#18 複数データ種の蓄積時、一部が許可されない場合にエラーにせず、許可されるデータ種のみ蓄積できる対応

### DIFF
--- a/src/resources/dto/CreateAPIKeyReqDto.ts
+++ b/src/resources/dto/CreateAPIKeyReqDto.ts
@@ -9,10 +9,11 @@ import {
     IsOptional,
     IsString,
     ValidateNested,
-    IsArray
+    IsArray,
+    IsBoolean
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
-import { transformToNumber } from '../../common/Transform';
+import { transformToBooleanFromString, transformToNumber } from '../../common/Transform';
 
 export class CodeObject {
     @Transform(({ value }) => { return transformToNumber(value); })
@@ -106,6 +107,11 @@ export class TargetObject {
     @IsOptional()
     @ValidateNested({ each: true })
         _code: any[] = [];
+
+    @Transform(({ value }) => { return transformToBooleanFromString(value); })
+    @IsBoolean()
+    @IsOptional()
+        allowPartialStore: boolean;
 }
 
 export default class CreateAPIKeyReqDto {

--- a/src/services/BookManageService.ts
+++ b/src/services/BookManageService.ts
@@ -96,8 +96,11 @@ export default class {
      * @param dataType
      * @param operator
      */
-    static async checkStorePermission (userId: string, wfCode: number, appCode: number, actorCode: number, dataType: any[], operator: OperatorDomain) {
-        const url = config.get('bookManageService.postStorePermission') + '';
+    static async checkStorePermission (userId: string, wfCode: number, appCode: number, actorCode: number, dataType: any[], operator: OperatorDomain, allowPartialStore: boolean = false) {
+        let url = config.get('bookManageService.postStorePermission') + '';
+        if (allowPartialStore) {
+            url = url + '?allowPartialStore=true';
+        }
         const data = JSON.stringify({
             userId: userId,
             wfCode: wfCode,

--- a/src/services/CreateAPIKeyService.ts
+++ b/src/services/CreateAPIKeyService.ts
@@ -88,7 +88,7 @@ export default class CreateAPIKeyService {
 
             // 蓄積定義による蓄積可否判定
             const result = await BookManageService.checkStorePermission(
-                item.caller.userId, wf, app, actor, targetDataType, operator);
+                item.caller.userId, wf, app, actor, targetDataType, operator, item.target.allowPartialStore);
 
             if (result.checkResult === true) {
                 // データ種を付与


### PR DESCRIPTION
# bugfix/#18 複数データ種の蓄積時、一部が許可されない場合にエラーにせず、許可されるデータ種のみ蓄積できる対応

## 修正内容

- 複数データ種の蓄積時、一部が許可されない場合にエラーにせず、許可されるデータ種のみ蓄積できる対応

fixes #18

## UT環境

```bash
$ node -v
v18.20.5

$ psql -U postgres -h localhost -p 5432 -c "SELECT version();"

                                                        version
-----------------------------------------------------------------------------------------------------------------------
 PostgreSQL 15.10 (Debian 15.10-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
(1 行)
```

### UT実行結果

```bash
$ npm run test:unit

> access-control-manage-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

 PASS  src/tests/CreateShareContinuousAPIKey.spec.ts (377.916 s)
  ● Console

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

 PASS  src/tests/CreateAPIKey.validator.spec.ts (40.316 s)
 PASS  src/tests/CreateShareTempAPIKey.spec.ts (40.009 s)
 PASS  src/tests/CreateStoreAPIKey.spec.ts (34.747 s)
  ● Console

    console.log
      post

      at src/tests/NonDataStubs.ts:191:21

 PASS  src/tests/CreateCatalogAPIKey.spec.ts (33.461 s)
  ● Console

    console.log
      Missing this namespace for test: catalog/ext/test-org/setting/actor/app/actor_1000021

      at src/tests/StubServer.ts:616:25

 PASS  src/tests/CreateBookAPIKey.spec.ts (30.917 s)
 PASS  src/tests/CreateOperatorAPIKey.spec.ts (34.619 s)
  ● Console

    console.log
      Missing this namespace for test: catalog/model/auth/not_exists

      at src/tests/StubServer.ts:616:25

    console.log
      Missing this namespace for test: catalog/model/setting/actor/pxr-root

      at src/tests/StubServer.ts:616:25

 PASS  src/tests/CreateAppWfUserAPIKey.spec.ts (35.094 s)
 PASS  src/tests/CreateActorAPIKey.spec.ts (37.702 s)
 PASS  src/tests/CreateSettingAPIKey.spec.ts (37.989 s)
(node:5993) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 message listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/tests/CreateJoinAPIKey.spec.ts (37.308 s)
 PASS  src/tests/CreateBlockAPIKey.spec.ts (34.131 s)
-------------------------------------------|---------|----------|---------|---------|-------------------------
File                                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s       
-------------------------------------------|---------|----------|---------|---------|-------------------------
All files                                  |   94.16 |       84 |   84.97 |   94.16 |                         
 domains                                   |   73.86 |      100 |   65.62 |   72.77 |                         
  ActorCatalogDomain.ts                    |     100 |      100 |     100 |     100 |                         
  BlockCatalogDomain.ts                    |     100 |      100 |     100 |     100 |                         
  MyBookListElement.ts                     |     100 |      100 |     100 |     100 |                         
  NumberCToken.ts                          |     100 |      100 |     100 |     100 |                         
  SharingCatalog.ts                        |       0 |      100 |       0 |       0 | 6-72                    
  SharingDataDefinition.ts                 |       0 |      100 |       0 |       0 | 6-51                    
  SharingRestrintionCatalog.ts             |   85.41 |      100 |   63.15 |   85.41 | 26,32,45,57,70,82,101   
  TemporarySharingDataDefinition.ts        |     100 |      100 |     100 |     100 |                         
 repositories                              |     100 |      100 |     100 |     100 |                         
  EntityOperation.ts                       |     100 |      100 |     100 |     100 |                         
 repositories/postgres                     |     100 |      100 |     100 |     100 |                         
  CallerRole.ts                            |     100 |      100 |     100 |     100 |                         
  TokenAccessHistory.ts                    |     100 |      100 |     100 |     100 |                         
  TokenGenerationHistory.ts                |     100 |      100 |     100 |     100 |                         
 resources                                 |   99.77 |    90.16 |     100 |   99.75 |                         
  CreateActorAPIKeyController.ts           |     100 |      100 |     100 |     100 |                         
  CreateAppWfUserAPIKeyController.ts       |     100 |      100 |     100 |     100 |                         
  CreateBlockAPIKeyController.ts           |     100 |      100 |     100 |     100 |                         
  CreateBookAPIKeyController.ts            |     100 |      100 |     100 |     100 |                         
  CreateCatalogAPIKeyController.ts         |     100 |      100 |     100 |     100 |                         
  CreateJoinAPIKeyController.ts            |     100 |      100 |     100 |     100 |                         
  CreateOperatorAPIKeyController.ts        |     100 |      100 |     100 |     100 |                         
  CreateSettingAPIKeyController.ts         |     100 |      100 |     100 |     100 |                         
  CreateShareContinuousAPIKeyController.ts |     100 |    84.21 |     100 |     100 | 68-72,90                
  CreateShareTempAPIKeyController.ts       |     100 |    83.33 |     100 |     100 | 60                      
  CreateStoreAPIKeyController.ts           |   97.82 |       60 |     100 |   97.67 | 53                      
 resources/dto                             |    97.6 |      100 |    92.3 |    98.3 |                         
  CreateAPIKeyReqDto.ts                    |   95.23 |      100 |   83.33 |   97.29 | 40                      
  CreateShareContinuousAPIKeyReqDto.ts     |   97.95 |      100 |   94.11 |   97.91 | 37                      
  CreateShareTempAPIKeyReqDto.ts           |     100 |      100 |     100 |     100 |                         
 resources/validator                       |    97.8 |    94.11 |     100 |   97.59 |                         
  BaseValidator.ts                         |   93.33 |    83.33 |     100 |   92.85 | 73,79                   
  CreateBlockAPIKeyValidator.ts            |     100 |      100 |     100 |     100 |                         
  CreateShareContinuousAPIKeyValidator.ts  |     100 |      100 |     100 |     100 |                         
  CreateShareTempAPIKeyValidator.ts        |     100 |      100 |     100 |     100 |                         
  CreateStoreAPIKeyValidator.ts            |     100 |      100 |     100 |     100 |                         
 services                                  |   94.57 |    81.17 |   92.72 |   95.07 |                         
  AccessControlService.ts                  |     100 |      100 |     100 |     100 |                         
  BookManageService.ts                     |   97.91 |     90.9 |     100 |   97.91 | 102                     
  CTokenLedgerService.ts                   |   92.85 |    91.66 |     100 |   92.85 | 29,35                   
  CatalogService.ts                        |   91.54 |    83.33 |    90.9 |   91.42 | 50-51,128,141-143       
  CreateAPIKeyService.ts                   |   97.48 |    73.63 |   94.73 |   97.95 | 199,385,394,421         
  IdService_Stub.ts                        |     100 |      100 |     100 |     100 |                         
  SharingDataService.ts                    |   88.07 |    85.29 |   83.33 |   89.21 | 173,191,198,203,210-218 
 services/dto                              |     100 |      100 |     100 |     100 |                         
  AccessControllerResult.ts                |     100 |      100 |     100 |     100 |                         
-------------------------------------------|---------|----------|---------|---------|-------------------------

Test Suites: 12 passed, 12 total
Tests:       200 passed, 200 total
Snapshots:   0 total
Time:        793.151 s
Ran all test suites.
```
